### PR TITLE
Error with Random.state on 1.9.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'http://rubygems.org'
+
+group :development do
+  gem 'mocha'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,6 @@ source 'http://rubygems.org'
 
 group :development do
   gem 'mocha'
+  gem 'rake'
+  gem 'rdoc'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ GEM
       metaclass (~> 0.0.1)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,14 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    json (1.6.3)
+    json (1.6.3-java)
     metaclass (0.0.1)
     mocha (0.10.0)
       metaclass (~> 0.0.1)
+    rake (0.9.2)
+    rdoc (3.11)
+      json (~> 1.4)
 
 PLATFORMS
   java
@@ -11,3 +16,5 @@ PLATFORMS
 
 DEPENDENCIES
   mocha
+  rake
+  rdoc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,12 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    metaclass (0.0.1)
+    mocha (0.10.0)
+      metaclass (~> 0.0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  mocha

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,9 @@ require 'rake'
 require 'rake/testtask'
 require 'rdoc/task'
 
+RDoc::Task.new do |rdoc|
+end
+
 # TODO - want other tests/tasks run by default? Add them to the list
 # task :default => [:spec, :features]
 task :default => :test

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 # TODO - want other tests/tasks run by default? Add them to the list
 # task :default => [:spec, :features]
+task :default => :test

--- a/lib/random_data/locations.rb
+++ b/lib/random_data/locations.rb
@@ -80,7 +80,7 @@ module RandomData
     # Returns a state 2-character abbreviation
     # Random.state = "IL"
     
-    def state
+    def state_code
       @@us_states.rand[1]
     end
 

--- a/lib/random_data/locations.rb
+++ b/lib/random_data/locations.rb
@@ -84,6 +84,14 @@ module RandomData
       @@us_states.rand[1]
     end
 
+    # This method is deprecated, and will not
+    # work in 1.9.x because Random already defines
+    # state as a private method. Use state_code
+    # instead.
+    def state
+      state_code
+    end
+
     # Returns a full state name
     #Random.state_full = "Texas"
 

--- a/lib/random_data/names.rb
+++ b/lib/random_data/names.rb
@@ -33,10 +33,10 @@ module RandomData
       if final.count == 1
         "#{final.first} #{@@company_types.rand}, #{@@incorporation_types.rand}"
       else
-        incorporation_type = rand(1).times.collect{|e| @@incorporation_types.rand}
-        company_type = rand(1).times.collect{|e| @@company_types.rand}
-        trailer = company_type ? " #{company_type}" : ""
-        trailer << ", #{incorporation_type}" if incorporation_type
+        incorporation_type = rand(17) % 2 == 0 ? @@incorporation_types.rand : nil
+        company_type = rand(17) % 2 == 0 ? @@company_types.rand : nil
+        trailer = company_type.nil? ? "" : " #{company_type}"
+        trailer << ", #{incorporation_type}" unless incorporation_type.nil?
         "#{final[0..-1].join(', ')} & #{final.last}#{trailer}"
       end
     end

--- a/lib/random_data/names.rb
+++ b/lib/random_data/names.rb
@@ -14,7 +14,34 @@ module RandomData
                      KIRBY KIRK LAKE LEE LEWIS MARTIN MARTINEZ MAJOR MILLER MOORE OATES PETERS PETERSON ROBERTSON 
                      ROBINSON RODRIGUEZ SMITH SMYTHE STEVENS TAYLOR THATCHER THOMAS THOMPSON WALKER WASHINGTON WHITE 
                      WILLIAMS WILSON YORKE)
+    @@incorporation_types = %w{LLC Inc Inc. Ltd. LP LLP Corp. PLLC}
+    @@company_types       = %w{Clothier Publishing Computing Consulting Engineering Industries Marketing Manufacturing}
 
+    # Returns a random company name
+    #
+    # >> Random.company_name
+    #
+    # "Harris & Thomas"
+
+    def companyname
+      num = rand(5)
+      if num == 0
+        num = 1
+      end
+      final = num.times.collect { @@lastnames.rand.capitalize }
+
+      if final.count == 1
+        "#{final.first} #{@@company_types.rand}, #{@@incorporation_types.rand}"
+      else
+        incorporation_type = rand(1).times.collect{|e| @@incorporation_types.rand}
+        company_type = rand(1).times.collect{|e| @@company_types.rand}
+        trailer = company_type ? " #{company_type}" : ""
+        trailer << ", #{incorporation_type}" if incorporation_type
+        "#{final[0..-1].join(', ')} & #{final.last}#{trailer}"
+      end
+    end
+
+    alias company_name companyname
     # Returns a random lastname
     #
     # >> Random.lastname

--- a/test/test_random_data.rb
+++ b/test/test_random_data.rb
@@ -46,7 +46,7 @@ class TestRandomData < Test::Unit::TestCase
   end
 
   def test_should_return_random_state
-    assert_equal "DE", Random.state    
+    assert_equal "DE", Random.state_code
   end
 
   def test_should_return_random_state_full

--- a/test/test_random_data.rb
+++ b/test/test_random_data.rb
@@ -102,6 +102,14 @@ class TestRandomData < Test::Unit::TestCase
     assert_equal "Donald Jones", Random.full_name 
   end
 
+  def test_should_return_random_companyname
+    assert_equal "Jones Consulting, PLLC", Random.companyname    
+  end
+
+  def test_should_return_random_company_name
+    assert_equal "Jones Consulting, PLLC", Random.company_name
+  end
+
   def test_should_return_random_alphanumeric
     assert_equal "8O3dNFmAUqYr2YEY", Random.alphanumeric    
   end

--- a/test/test_random_data.rb
+++ b/test/test_random_data.rb
@@ -103,11 +103,13 @@ class TestRandomData < Test::Unit::TestCase
   end
 
   def test_should_return_random_companyname
-    assert_equal "Jones Consulting, PLLC", Random.companyname    
+    srand(17)
+    assert_equal "Garcia Marketing, Corp.", Random.companyname    
   end
 
   def test_should_return_random_company_name
-    assert_equal "Jones Consulting, PLLC", Random.company_name
+    srand(9999999999)
+    assert_equal "Anthony, Edwards & Edwards Publishing", Random.company_name
   end
 
   def test_should_return_random_alphanumeric


### PR DESCRIPTION
Random.state raises a private method error when run on 1.9.x because the core Random class has a private state method (which means something very different, obviously). So, I added a RandomData::Locations#state_code method and deprecated the RandomData::Locations#state method.
