### PR TITLE
Added a way to generate a random US mobile device number

### DIFF
--- a/lib/random_data/contact_info.rb
+++ b/lib/random_data/contact_info.rb
@@ -3,6 +3,11 @@ module RandomData
   
   module ContactInfo
 
+   # Returns a randomly-generated string of represents an 11 digit US mobile device number.
+   def mdn
+     "1#{rand(800) + 200}#{rand(800)+200}#{rand(9000)+1000}"
+   end
+
    # Returns a randomly-generated string of digits that roughly resembles a US telephone number.  Not guaranteed to be a valid area code.
    def phone
      "#{rand(900) + 100}-#{rand(900)+100}-#{rand(10000)+1000}"

--- a/test/test_random_data.rb
+++ b/test/test_random_data.rb
@@ -6,6 +6,10 @@ class TestRandomData < Test::Unit::TestCase
     # to make random numbers deterministic for testing purposes
     srand(100)
   end
+
+  def test_should_return_random_mdn
+    assert_equal "17209929039", Random.mdn
+  end
   
   def test_should_return_random_phone_number
     assert_equal "620-892-9039", Random.phone


### PR DESCRIPTION
Added Random.mdn method to generate a random US mobile device number. The MDN for US carriers is essentially the telephone number tied for a cell phone but does not have any dashes or other punctuation. For example, if the cell phone number is 555-434-5554 then the MDN will be 15554345554.
