### PR TITLE
Support for RubyMotion

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 # TODO - want other tests/tasks run by default? Add them to the list
 # task :default => [:spec, :features]

--- a/lib/bubble-wrap/random_data.rb
+++ b/lib/bubble-wrap/random_data.rb
@@ -1,0 +1,14 @@
+require 'bubble-wrap/loader'
+
+BubbleWrap.require 'lib/random_data/*.rb' do
+  file('lib/random_data/random_ext.rb').depends_on [
+    'lib/random_data/booleans.rb',
+    'lib/random_data/contact_info.rb',
+    'lib/random_data/dates.rb',
+    'lib/random_data/grammar.rb',
+    'lib/random_data/locations.rb',
+    'lib/random_data/names.rb',
+    'lib/random_data/numbers.rb',
+    'lib/random_data/text.rb'
+  ]
+end

--- a/lib/random_data.rb
+++ b/lib/random_data.rb
@@ -1,5 +1,6 @@
 dir = "#{File.dirname(__FILE__)}/random_data"
 
+require 'date'
 require "#{dir}/array_randomizer"
 require "#{dir}/booleans"
 require "#{dir}/contact_info"
@@ -12,52 +13,3 @@ require "#{dir}/markov"
 require "#{dir}/grammar"
 require "#{dir}/version"
 
-class Random
-  extend RandomData::Booleans
-  extend RandomData::ContactInfo
-  extend RandomData::Dates
-  extend RandomData::Grammar
-  extend RandomData::Locations
-  extend RandomData::Names
-  extend RandomData::Numbers
-  extend RandomData::Text
-
-  # Looks for a file in the load path with the name methodname.dat, reads the lines from that file, then gives you a random line from that file.
-  # Raises an error if it can't find the file.  For example, given a file named "horse.dat" in your load path:
-  # >> Random.horse
-  # => "Stallion"
-  # >> Random.horse
-  # => "Pony"
-  # >> Random.horse
-  # => "Mare"
-  # >> Random.horse
-  # => "Clydesdale"
-  # >> Random.horse
-  # => "Stallion"
-  # >> Random.horse
-  # => "Mare"
-  
-  def self.method_missing(methodname)
-    thing = "#{methodname}.dat"
-    filename = find_path(thing)
-
-    if filename.nil?
-      super
-    else
-      array = []
-      File.open(filename, 'r') { |f| array = f.read.split(/[\r\n]+/) }
-      return array.rand
-    end
-  end
-  
-  private
-  
-  def self.find_path(filename)
-    $:.each do |path|
-      new_path = File.join(path,filename)
-      return new_path if File.exist?(new_path)
-    end    
-    return nil
-  end
-  
-end

--- a/lib/random_data/dates.rb
+++ b/lib/random_data/dates.rb
@@ -1,5 +1,3 @@
-require 'date'
-
 module RandomData
   
   # Defines methods for random date generation

--- a/lib/random_data/random_ext.rb
+++ b/lib/random_data/random_ext.rb
@@ -1,0 +1,50 @@
+class Random
+  extend RandomData::Booleans
+  extend RandomData::ContactInfo
+  extend RandomData::Dates
+  extend RandomData::Grammar
+  extend RandomData::Locations
+  extend RandomData::Names
+  extend RandomData::Numbers
+  extend RandomData::Text
+
+  # Looks for a file in the load path with the name methodname.dat, reads the lines from that file, then gives you a random line from that file.
+  # Raises an error if it can't find the file.  For example, given a file named "horse.dat" in your load path:
+  # >> Random.horse
+  # => "Stallion"
+  # >> Random.horse
+  # => "Pony"
+  # >> Random.horse
+  # => "Mare"
+  # >> Random.horse
+  # => "Clydesdale"
+  # >> Random.horse
+  # => "Stallion"
+  # >> Random.horse
+  # => "Mare"
+  
+  def self.method_missing(methodname)
+    thing = "#{methodname}.dat"
+    filename = find_path(thing)
+
+    if filename.nil?
+      super
+    else
+      array = []
+      File.open(filename, 'r') { |f| array = f.read.split(/[\r\n]+/) }
+      return array.rand
+    end
+  end
+  
+  private
+  
+  def self.find_path(filename)
+    $:.each do |path|
+      new_path = File.join(path,filename)
+      return new_path if File.exist?(new_path)
+    end    
+    return nil
+  end
+  
+end
+


### PR DESCRIPTION
This necessitated refactoring the files to avoid using "require" in code that would get compiled by RubyMotion, and adding a "bubble-wrapped" file, which is the conventional way to expose code to RubyMotion.
